### PR TITLE
Corrección de error de bucle referencial

### DIFF
--- a/Domain/Entities/Movie.cs
+++ b/Domain/Entities/Movie.cs
@@ -22,7 +22,7 @@ namespace Domain.Entities
         [Required]
         [ForeignKey("DirectorId")]
         public int DirectorId { get; set; }
-        public Director DirectorMovie { get; set; } 
+        //public Director DirectorMovie { get; set; } 
 
         public List<Show> Shows { get; set; }
 

--- a/Infrastructure/Data/ApplicationContext.cs
+++ b/Infrastructure/Data/ApplicationContext.cs
@@ -30,7 +30,7 @@ namespace Infrastructure.Data
 
             modelBuilder.Entity<Director>()
                 .HasMany(d => d.Movies)
-                .WithOne(m => m.DirectorMovie)
+                .WithOne(/*m => m.DirectorMovie*/)
                 .HasForeignKey(m => m.DirectorId)
                 .OnDelete(DeleteBehavior.Cascade); //asegura que si un director se elimina, todas sus peliculas asociadas también se eliminarán.
 

--- a/Infrastructure/Data/RepositoryMovie.cs
+++ b/Infrastructure/Data/RepositoryMovie.cs
@@ -19,15 +19,21 @@ namespace Infrastructure.Data
     
         public ICollection<Movie>? GetAllMovies()
         {
-            var listMovies = _context.Movies.Include(m => m.DirectorMovie).Include(m => m.Shows).ToList()
+            var listMovies = _context.Movies
+                /*Include(m => m.DirectorMovie).*/
+                .Include(m => m.Shows).ToList()
+
             ?? throw new Exception("Movies not found");
             return listMovies;
         }
 
         public Movie? GetMoviesById(int Id) 
         {
-            var movie = _context.Movies.Include(m => m.DirectorMovie).Include(m => m.Shows).FirstOrDefault(m => m.Id == Id)
-                ?? throw new Exception("Movie not found");
+            var movie = _context.Movies
+                /*Include(m => m.DirectorMovie)*/
+                .Include(m => m.Shows).FirstOrDefault(m => m.Id == Id)
+
+            ?? throw new Exception("Movie not found");
             return movie;
         }
     }


### PR DESCRIPTION
Los endpoints GetAll y GetById de la entidad Director arrojaban un error por un bucle con una referencia cíclica con la entidad Movie. Así que quité el atributo que creo ocasionaba el bucle, que además no aportaba ningún beneficio.